### PR TITLE
Fixes #51 : Suppress color instructions in logs for maven > 3.5.0

### DIFF
--- a/citrus-admin-web/src/main/java/com/consol/citrus/admin/service/command/maven/MavenArchetypeCommand.java
+++ b/citrus-admin-web/src/main/java/com/consol/citrus/admin/service/command/maven/MavenArchetypeCommand.java
@@ -51,7 +51,6 @@ public class MavenArchetypeCommand extends MavenCommand {
 
         commandBuilder.append(GENERATE);
 
-        commandBuilder.append("-B ");
         commandBuilder.append(String.format("-DarchetypeGroupId=%s ", archetype.getArchetypeGroupId()));
         commandBuilder.append(String.format("-DarchetypeArtifactId=%s ", archetype.getArchetypeArtifactId()));
         commandBuilder.append(String.format("-DarchetypeVersion=%s ", archetype.getArchetypeVersion()));

--- a/citrus-admin-web/src/main/java/com/consol/citrus/admin/service/command/maven/MavenCommand.java
+++ b/citrus-admin-web/src/main/java/com/consol/citrus/admin/service/command/maven/MavenCommand.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class MavenCommand extends AbstractTerminalCommand {
 
-    private static final String MVN = "mvn ";
+    private static final String MVN = "mvn -B";
     protected static final String CLEAN = "clean ";
     protected static final String COMPILE = "compile ";
     protected static final String PACKAGE = "package ";


### PR DESCRIPTION
Always use Maven batch mode (`-B`), since Maven will never be executed interactively from the Citrus Admin UI. This is also the recommended way of executing Maven for CI servers.